### PR TITLE
Don't shell out to txt2html, call rfc2html

### DIFF
--- a/SocialHandler.py
+++ b/SocialHandler.py
@@ -14,6 +14,7 @@ import copy
 import URLShortener
 import chardet
 from sets import Set
+from rfc2html import markup
 
 
 class SocialHandler(object):
@@ -211,39 +212,7 @@ class SocialHandler(object):
 
 
     def TextToHtml(self, msg=unicode("","utf8") ):
-        # Convert links to HTML in a text message
-        # Relied on external tool, txt2html
-
-        # write message to file for conversion
-        pid = os.getpid()
-        text_file = open("/tmp/txt2html_%d.txt" % (pid), "w")
-
-        #text_file.write(msg.encode('utf8'))
-        text_file.write(self.texthandler(msg).encode('utf8'))
-
-        text_file.close();
-
-        # Convert using tool
-        html_message = unicode("","utf8")
-        try:
-            #html_message = unicode(subprocess.check_output(["txt2html", "--infile", "/tmp/txt2html_%d.txt" % (pid)]))
-            html_message = subprocess.check_output(["txt2html", "--infile", "/tmp/txt2html_%d.txt" % (pid)])
-
-        except subprocess.CalledProcessError:
-            print self.texthandler("There was a problem trying to call the txt2html program - make sure it is installed correctly.")
-            sys.exit(-1)
-            pass
-
-        # excerpt the content of the <body> tags
-
-        html_message = self.texthandler(html_message)
-
-        body_begin = html_message.find(u'<body>') + 6
-        body_end   = html_message.find(u'</body>')
-
-        html_message = html_message[body_begin:body_end]
-
-        return html_message
+        return markup(html_message)
 
 
     def T2H_URLs(self, text=unicode("","utf8")):


### PR DESCRIPTION
Installing txt2html may be impossible for users without root access.
The rfc2html module is the only one I could find: seems maintained
and does a decent job (it outputs HTML without a body tag).